### PR TITLE
Fix mysql authentication problem

### DIFF
--- a/docker/configurations/mysql.cnf
+++ b/docker/configurations/mysql.cnf
@@ -1,0 +1,33 @@
+# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+#
+# The MySQL  Server configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[mysqld]
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+datadir         = /var/lib/mysql
+secure-file-priv= NULL
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# Custom config should go here
+!includedir /etc/mysql/conf.d/
+
+default_authentication_plugin=mysql_native_password

--- a/docker/services/mysql.yml
+++ b/docker/services/mysql.yml
@@ -6,6 +6,7 @@ services:
     image: mysql:8.0
     volumes:
       - mysql:/var/lib/mysql
+      - ../configurations/mysql.cnf:/etc/mysql/my.cnf
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}


### PR DESCRIPTION
Mysql 8.0 changed default-authentication-plugin from
mysql_native_password to caching_sha2_password. As application
still not support the new authentication plugin, mysql
needs to fallback to authentication plugin that was default
before version 8.0.